### PR TITLE
Add proper run hints to support dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-var PLUGIN_NAME, ProgressBar, async, atom, childProcess, fs, getApmPath, grs, isFile, path, spawn, through2, util, wrench;
+var File, PLUGIN_NAME, ProgressBar, async, atom, childProcess, fs, getApmPath, grs, isFile, path, spawn, through2, util, wrench;
 
 fs = require('fs');
 
@@ -17,6 +17,8 @@ through2 = require('through2');
 childProcess = require('child_process');
 
 ProgressBar = require('progress');
+
+File = require('vinyl');
 
 PLUGIN_NAME = 'gulp-atom-shell';
 
@@ -44,7 +46,7 @@ module.exports = atom = function(options) {
   if (typeof options.platforms === 'string') {
     options.platforms = [options.platforms];
   }
-  stream = through2();
+  stream = through2.obj();
   platforms = ['darwin', 'win32', 'linux', 'darwin-x64', 'linux-ia32', 'linux-x64', 'win32-ia32', 'win64-64'];
   async.eachSeries(options.platforms, function(platform, callback) {
     var cacheFile, cachePath, pkg, releasePath;
@@ -129,16 +131,32 @@ module.exports = atom = function(options) {
           excludeHiddenUnix: false,
           inflateSymlinks: false
         });
-        return next();
+        return next(null, platform.indexOf('darwin') < 0 && releasePath || path.join(releasePath, 'Atom.app'));
       }
     ], function(error, results) {
+      var execution, releaseDir;
+      releaseDir = results[results.length - 1];
+      execution = (function() {
+        switch (false) {
+          case !(platform.indexOf('darwin') >= 0):
+            return 'Contents/MacOS/Atom';
+          case !(platform.indexOf('win') >= 0):
+            return 'atom.exe';
+          default:
+            return 'atom';
+        }
+      })();
+      stream.write(new File({
+        base: releaseDir,
+        path: path.join(releaseDir, execution)
+      }));
       return callback(error);
     });
   }, function(error) {
     if (error) {
       stream.emit('error', error);
     }
-    return stream.emit('end', {});
+    return stream.end();
   });
   return stream;
 };

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
     "should": "^3.3.1"
   },
   "dependencies": {
-    "gulp-util": "^2.2.14",
-    "through2": "^0.4.1",
-    "wrench": "^1.5.8",
     "async": "^0.9.0",
+    "grs": "^0.1.2",
+    "gulp-util": "^2.2.14",
     "progress": "^1.1.5",
-    "grs": "^0.1.2"
+    "through2": "^0.4.1",
+    "vinyl": "^0.2.3",
+    "wrench": "^1.5.8"
   }
 }


### PR DESCRIPTION
As a bonus, it would start emitting a File object for every platform. Each object would contain a path of the app folder (one you would want to distribute) as `file.base` and full path to executable (you may want to rename or execute) as `file.path`.

Additional info:
- https://github.com/gulpjs/gulp/blob/master/docs/writing-a-plugin/README.md#streaming-file-objects
- https://github.com/gulpjs/gulp/blob/master/docs/API.md#deps
