### PR TITLE
Change win64-64 platform name to win32-x64, fixes #6

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ module.exports = atom = function(options) {
     options.platforms = [options.platforms];
   }
   stream = through2.obj();
-  platforms = ['darwin', 'win32', 'linux', 'darwin-x64', 'linux-ia32', 'linux-x64', 'win32-ia32', 'win64-64'];
+  platforms = ['darwin', 'win32', 'linux', 'darwin-x64', 'linux-ia32', 'linux-x64', 'win32-ia32', 'win32-x64'];
   async.eachSeries(options.platforms, function(platform, callback) {
     var cacheFile, cachePath, pkg, releasePath;
     if (platform === 'osx') {


### PR DESCRIPTION
Looks like "win32-x64" is the right name of the 64bit Windows release. 
Fixes issue #6 .